### PR TITLE
Restore and implement unsold round buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,11 @@ const App = () => (
                 <LiveAuction />
               </Layout>
             } />
+            <Route path="/live" element={
+              <Layout>
+                <LiveAuction />
+              </Layout>
+            } />
             <Route path="/teams" element={
               <Layout>
                 <Teams />

--- a/src/pages/LiveAuction.tsx
+++ b/src/pages/LiveAuction.tsx
@@ -556,6 +556,27 @@ const LiveAuction = () => {
 
   return (
     <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 md:p-6 space-y-6 md:space-y-8">
+      {/* Sticky Unsold Controls for guaranteed visibility */}
+      <div className="sticky top-0 z-20 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 py-2">
+        <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4">
+          <Button 
+            variant="secondary"
+            disabled={!user}
+            onClick={startUnsoldRound}
+            className="w-full sm:w-auto"
+          >
+            Start Unsold Round
+          </Button>
+          <Button 
+            variant="secondary"
+            disabled={!user}
+            onClick={resetUnsoldPlayers}
+            className="w-full sm:w-auto"
+          >
+            Reset Unsold
+          </Button>
+        </div>
+      </div>
       {/* Auction Controls */}
       <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4">
         <Button 

--- a/src/pages/LiveAuction.tsx
+++ b/src/pages/LiveAuction.tsx
@@ -883,31 +883,25 @@ const LiveAuction = () => {
 
       {error && <p className="text-destructive text-center text-sm">{error}</p>}
 
-      {/* Main Round Controls (end of page) */}
-      {currentRound === 'main' && (
-        <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4 mt-4">
-          <Button 
-            variant="secondary"
-            disabled={!user}
-            onClick={startUnsoldRound}
-            className="w-full sm:w-auto"
-          >
-            Start Unsold Round
-          </Button>
-          <Button 
-            variant="secondary"
-            disabled={!user}
-            onClick={resetUnsoldPlayers}
-            className="w-full sm:w-auto"
-          >
-            Reset Unsold
-          </Button>
-        </div>
-      )}
-
-      {/* Unsold Round Controls (end of page) */}
-      {currentRound === 'unsold' && (
-        <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4 mt-4">
+      {/* Persistent Bottom Controls */}
+      <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4 mt-4">
+        <Button 
+          variant="secondary"
+          disabled={!user}
+          onClick={startUnsoldRound}
+          className="w-full sm:w-auto"
+        >
+          Start Unsold Round
+        </Button>
+        <Button 
+          variant="secondary"
+          disabled={!user}
+          onClick={resetUnsoldPlayers}
+          className="w-full sm:w-auto"
+        >
+          Reset Unsold
+        </Button>
+        {currentRound === 'unsold' && (
           <Button 
             variant="secondary"
             disabled={!user}
@@ -916,8 +910,8 @@ const LiveAuction = () => {
           >
             Return to Main Round
           </Button>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Auction Summary Dialog */}
       <Dialog open={showSummary} onOpenChange={setShowSummary}>

--- a/src/pages/LiveAuction.tsx
+++ b/src/pages/LiveAuction.tsx
@@ -557,7 +557,7 @@ const LiveAuction = () => {
   return (
     <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 md:p-6 space-y-6 md:space-y-8">
       {/* Sticky Unsold Controls for guaranteed visibility */}
-      <div className="sticky top-0 z-20 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 py-2">
+      <div className="sticky top-0 z-50 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 py-2">
         <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4">
           <Button 
             variant="secondary"

--- a/src/pages/LiveAuction.tsx
+++ b/src/pages/LiveAuction.tsx
@@ -438,7 +438,7 @@ const LiveAuction = () => {
       if (error) throw error;
       
       setCurrentRound('unsold');
-      fetchPlayer();
+      fetchPlayer('unsold');
     } catch (err) {
       console.error('Error starting unsold round:', err);
     }
@@ -477,13 +477,13 @@ const LiveAuction = () => {
         .update({ is_active: false })
         .eq('is_active', true);
       setCurrentRound('main');
-      fetchPlayer();
+      fetchPlayer('main');
     } catch (err) {
       console.error('Error returning to main round:', err);
     }
   };
 
-  const fetchPlayer = async () => {
+  const fetchPlayer = async (roundOverride?: 'main' | 'unsold') => {
     if (!user) return; // Only authenticated users can start auction
     
     setIsLoading(true);
@@ -506,7 +506,8 @@ const LiveAuction = () => {
         .not("name", "in", `(${auctionedPlayerNames.join(",")})`)
         .order("role_number", { ascending: true });
       
-      if (currentRound === 'unsold') {
+      const effectiveRound = roundOverride ?? currentRound;
+      if (effectiveRound === 'unsold') {
         playerQuery = playerQuery.eq('is_unsold', true);
       } else {
         playerQuery = playerQuery.eq('is_unsold', false);
@@ -634,6 +635,22 @@ const LiveAuction = () => {
           }}
         >
           Reset Auction
+        </Button>
+        <Button 
+          variant="secondary"
+          disabled={!user}
+          onClick={startUnsoldRound}
+          className="w-full sm:w-auto"
+        >
+          Start Unsold Round
+        </Button>
+        <Button 
+          variant="secondary"
+          disabled={!user}
+          onClick={resetUnsoldPlayers}
+          className="w-full sm:w-auto"
+        >
+          Reset Unsold
         </Button>
         <Button
           variant="outline"

--- a/src/pages/LiveAuction.tsx
+++ b/src/pages/LiveAuction.tsx
@@ -556,27 +556,6 @@ const LiveAuction = () => {
 
   return (
     <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 md:p-6 space-y-6 md:space-y-8">
-      {/* Sticky Unsold Controls for guaranteed visibility */}
-      <div className="sticky top-0 z-50 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 py-2">
-        <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4">
-          <Button 
-            variant="secondary"
-            disabled={!user}
-            onClick={startUnsoldRound}
-            className="w-full sm:w-auto"
-          >
-            Start Unsold Round
-          </Button>
-          <Button 
-            variant="secondary"
-            disabled={!user}
-            onClick={resetUnsoldPlayers}
-            className="w-full sm:w-auto"
-          >
-            Reset Unsold
-          </Button>
-        </div>
-      </div>
       {/* Auction Controls */}
       <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4">
         <Button 
@@ -904,35 +883,7 @@ const LiveAuction = () => {
 
       {error && <p className="text-destructive text-center text-sm">{error}</p>}
 
-      {/* Persistent Bottom Controls */}
-      <div className="flex flex-col sm:flex-row justify-center gap-2 sm:gap-4 mt-4">
-        <Button 
-          variant="secondary"
-          disabled={!user}
-          onClick={startUnsoldRound}
-          className="w-full sm:w-auto"
-        >
-          Start Unsold Round
-        </Button>
-        <Button 
-          variant="secondary"
-          disabled={!user}
-          onClick={resetUnsoldPlayers}
-          className="w-full sm:w-auto"
-        >
-          Reset Unsold
-        </Button>
-        {currentRound === 'unsold' && (
-          <Button 
-            variant="secondary"
-            disabled={!user}
-            onClick={returnToMainRound}
-            className="w-full sm:w-auto"
-          >
-            Return to Main Round
-          </Button>
-        )}
-      </div>
+      
 
       {/* Auction Summary Dialog */}
       <Dialog open={showSummary} onOpenChange={setShowSummary}>


### PR DESCRIPTION
Add "Start Unsold Round" and "Reset Unsold" buttons back to the Live Auction page and ensure unsold round functionality correctly fetches only unsold players.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bcff3e2-4c7f-43ab-97e9-4d45ddaa5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bcff3e2-4c7f-43ab-97e9-4d45ddaa5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

